### PR TITLE
ignore parameters that are not found on delete, include keys in error…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,14 @@
 # Build the manager binary
-# FROM golang:1.19 as builder
-# ARG TARGETOS
-# ARG TARGETARCH
+FROM golang:1.19 as builder
 
-# WORKDIR /workspace
-# Copy the Go Modules manifests
-# COPY go.mod go.mod
-# COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-# RUN go mod download
+WORKDIR /workspace
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o manager -mod=vendor cmd/main.go
 
-# Copy the go source
-# COPY manager .
-
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-# RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod=vendor -o manager cmd/main.go
-
-# Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY manager .
+COPY --from=builder /workspace/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
1. Include parameter name in status message on error
2. Resources upon deletion used get halted with 60 secs timeout on error. Excludes parameters that are not found from this requeue with timeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the build process for more efficient deployment.
- **New Features**
	- Enhanced error handling and logging in secret management operations.
- **Chores**
	- Improved secret controller logic to optimize performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->